### PR TITLE
import etree from xml instead of markdown.util

### DIFF
--- a/pymarkdown-video.py
+++ b/pymarkdown-video.py
@@ -1,6 +1,6 @@
 from markdown.extensions import Extension
 from markdown.treeprocessors import Treeprocessor
-from markdown.util import etree
+import xml.etree.ElementTree as etree
 import urllib.parse as urlparse, os
 
 # List of video file extension and format supported


### PR DESCRIPTION
`markdown.util.etree` was deprecated in 3.2 and removed in 3.4.

It was not working for me with the latest version of python-markdown. With the fix everything works fine now. Thanks for the nice extension!